### PR TITLE
[FIX] max discount shouldn't prevent sale order copy

### DIFF
--- a/models/account_approval.py
+++ b/models/account_approval.py
@@ -23,12 +23,32 @@ class SaleOrderLine(models.Model):
 
     @api.constrains('discount')
     def _check_max_allowed_discount(self):
+        if not self._context.get('bypass_max_discount_check'):
+            max_discount = self._get_max_allowed_discount()
+            for line in self:
+                if line.discount > max_discount:
+                    raise ValidationError("Vous ne pouvez pas appliquer une réduction supérieure à ce que votre niveau permet (%s%%). Demandez à votre manager pour accorder une réduction supérieure." % max_discount)
+
+    @api.model
+    def _get_max_allowed_discount(self):
         max_discount_allowed = self.env['discount.settings'].search_read([
             ('group_ids', 'in', self.env.user.groups_id.ids)
         ], ['max_amount'], order='max_amount DESC', limit=1)
         fallback_value = 999 if self.env.is_admin() else 0
-        max_discount = max_discount_allowed and max_discount_allowed[0]['max_amount'] or fallback_value
+        return max_discount_allowed and max_discount_allowed[0]['max_amount'] or fallback_value
 
-        for line in self:
-            if line.discount > max_discount:
-                raise ValidationError("Vous ne pouvez pas appliquer une réduction supérieure à ce que votre niveau permet (%s%%). Demandez à votre manager pour accorder une réduction supérieure." % max_discount)
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.returns('self', lambda value: value.id)
+    def copy(self, default=None):
+        self.ensure_one()
+        copy_order = super(SaleOrder, self.with_context(bypass_max_discount_check=True)).copy(default=default)
+        # reduce the non authorized discount amount to max allowed amount
+        max_discount = self.env['sale.order.line']._get_max_allowed_discount()
+        lines_to_cap = copy_order.order_line.filtered(lambda l: l.discount > max_discount)
+        if lines_to_cap:
+            lines_to_cap.discount = max_discount
+            lines_to_cap.order_id.message_post(body="Ce devis a été copié depuis un devis qui contenait une remise supérieur à %s%%. La remise a donc été réduite au montant maximum autorisé par votre niveau." % max_discount)
+        return copy_order


### PR DESCRIPTION
Since [1] where a user could not set a discount greated than what he is
allowed to, such users would not be able to copy sale order(s)
containing discount greater than that max allowed discount.

A solution is here provided, to allow the copy by bypassing the max
discount check during the copy, and then reducing the discount which are
greater than the maximum allowed to the maximum allowed discount.

[1]: https://github.com/sbuhl/account_approval/commit/99c5d8bbac65dc6d40bd225f0878a6bc6c131a12

Fixes #7