### PR TITLE
[FIX] Add admin check to bypass discount validation in sales lines

### DIFF
--- a/models/account_approval.py
+++ b/models/account_approval.py
@@ -42,6 +42,10 @@ class SaleOrderLine(models.Model):
         for line in self:
             pricelist_item_name = line.pricelist_item_id.name if line.pricelist_item_id else 'None'
             _logger.info('Checking discount for line: %s, Pricelist Item ID: %s, Pricelist Item Name: %s', line.id, line.pricelist_item_id.id if line.pricelist_item_id else 'None', pricelist_item_name)
+                
+            if self.env.is_admin():
+                continue  # Si admin, on saute toutes les vérifications
+
             if not self._context.get('bypass_max_discount_check'):
                 if line.pricelist_item_id:
                     pricelist_item = line.pricelist_item_id


### PR DESCRIPTION
- Administrators can bypass all discount checks.
- Added `self.env.user.has_group('base.group_system')` to check if the current user is a super admin.
